### PR TITLE
Destroy rovers

### DIFF
--- a/pkg/rove/world_test.go
+++ b/pkg/rove/world_test.go
@@ -49,7 +49,7 @@ func TestWorld_DestroyRover(t *testing.T) {
 	b, err := world.SpawnRover("")
 	assert.NoError(t, err)
 
-	err = world.DestroyRover(a)
+	err = world.destroyRover(a)
 	assert.NoError(t, err, "Error returned from rover destroy")
 
 	// Basic duplicate check
@@ -130,7 +130,9 @@ func TestWorld_RadarFromRover(t *testing.T) {
 
 func TestWorld_RoverDamage(t *testing.T) {
 	world := NewWorld(2)
-	a, err := world.SpawnRover("")
+	acc, err := world.Accountant.RegisterAccount("tmp")
+	assert.NoError(t, err)
+	a, err := world.SpawnRover(acc.Name)
 	assert.NoError(t, err)
 
 	pos := maths.Vector{
@@ -155,6 +157,20 @@ func TestWorld_RoverDamage(t *testing.T) {
 	assert.NoError(t, err, "couldn't get rover info")
 	assert.Equal(t, info.Integrity-1, newinfo.Integrity, "rover should have lost integrity")
 	assert.Contains(t, newinfo.Logs[len(newinfo.Logs)-1].Text, "collision", "Rover logs should contain the collision")
+
+	// Keep moving to damage the rover
+	for i := 0; i < info.Integrity-1; i++ {
+		vec, err := world.TryMoveRover(a, roveapi.Bearing_North)
+		assert.NoError(t, err, "Failed to move rover")
+		assert.Equal(t, pos, vec, "Rover managed to move into large rock")
+	}
+
+	// Rover should have been destroyed now
+	_, err = world.GetRover(a)
+	assert.Error(t, err)
+
+	_, obj := world.Atlas.QueryPosition(info.Pos)
+	assert.Equal(t, roveapi.Object_RoverDormant, obj.Type)
 }
 
 func TestWorld_Daytime(t *testing.T) {

--- a/pkg/rove/world_test.go
+++ b/pkg/rove/world_test.go
@@ -49,7 +49,7 @@ func TestWorld_DestroyRover(t *testing.T) {
 	b, err := world.SpawnRover("")
 	assert.NoError(t, err)
 
-	err = world.destroyRover(a)
+	err = world.DestroyRover(a)
 	assert.NoError(t, err, "Error returned from rover destroy")
 
 	// Basic duplicate check
@@ -164,6 +164,9 @@ func TestWorld_RoverDamage(t *testing.T) {
 		assert.NoError(t, err, "Failed to move rover")
 		assert.Equal(t, pos, vec, "Rover managed to move into large rock")
 	}
+
+	// Tick the world to check for rover deaths
+	world.Tick()
 
 	// Rover should have been destroyed now
 	_, err = world.GetRover(a)


### PR DESCRIPTION
Closes #36

Rovers are now destroyed and turned dormant when they die, and a new rover is spawned for the account.