### PR TITLE
Add TLS to server-client communications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,7 @@ gen:
 	protoc --proto_path proto --go_out=plugins=grpc,paths=source_relative:proto/ proto/roveapi/roveapi.proto
 
 test:
-	@echo Unit tests
-	go test -v ./...
-
-	@echo Integration tests
+	@echo Run unit and integration tests
 	docker-compose -f docker-compose-test.yml up --build --exit-code-from=rove-tests --abort-on-container-exit rove-tests
 	docker-compose -f docker-compose-test.yml down
 	go tool cover -html=/tmp/coverage-data/c.out -o /tmp/coverage.html

--- a/cmd/rove-server/internal/server.go
+++ b/cmd/rove-server/internal/server.go
@@ -113,7 +113,7 @@ func (s *Server) Initialise(fillWorld bool) (err error) {
 	// Load TLS
 	var opts []grpc.ServerOption
 	if len(os.Getenv("NO_TLS")) == 0 {
-		pem := path.Join("/etc/letsencrypt/live/", cert, "cert.pem")
+		pem := path.Join("/etc/letsencrypt/live/", cert, "fullchain.pem")
 		key := path.Join("/etc/letsencrypt/live/", cert, "privkey.pem")
 		creds, err := credentials.NewServerTLSFromFile(pem, key)
 		if err != nil {

--- a/cmd/rove-server/internal/server_test.go
+++ b/cmd/rove-server/internal/server_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"os"
 	"testing"
 )
 
@@ -30,6 +31,7 @@ func TestNewServer_OptionPersistentData(t *testing.T) {
 }
 
 func TestServer_Run(t *testing.T) {
+	os.Setenv("NO_TLS", "1")
 	server := NewServer()
 	if server == nil {
 		t.Error("Failed to create server")
@@ -45,6 +47,7 @@ func TestServer_Run(t *testing.T) {
 }
 
 func TestServer_RunPersistentData(t *testing.T) {
+	os.Setenv("NO_TLS", "1")
 	server := NewServer(OptionPersistentData())
 	if server == nil {
 		t.Error("Failed to create server")

--- a/cmd/rove/main.go
+++ b/cmd/rove/main.go
@@ -187,9 +187,7 @@ func InnerMain(command string, args ...string) error {
 		return fmt.Errorf("no host set in %s, set one with '%s config {HOST}'", ConfigPath(), os.Args[0])
 	}
 
-	tls := &tls.Config{
-		InsecureSkipVerify: true,
-	}
+	tls := &tls.Config{}
 
 	// Set up the server
 	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", config.Host, gRPCport), grpc.WithTransportCredentials(credentials.NewTLS(tls)))

--- a/cmd/rove/main.go
+++ b/cmd/rove/main.go
@@ -187,12 +187,15 @@ func InnerMain(command string, args ...string) error {
 		return fmt.Errorf("no host set in %s, set one with '%s config {HOST}'", ConfigPath(), os.Args[0])
 	}
 
-	tls := &tls.Config{
-		InsecureSkipVerify: true,
+	var opts []grpc.DialOption
+	if len(os.Getenv("NO_TLS")) == 0 {
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+	} else {
+		opts = append(opts, grpc.WithInsecure())
 	}
 
 	// Set up the server
-	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", config.Host, gRPCport), grpc.WithTransportCredentials(credentials.NewTLS(tls)))
+	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", config.Host, gRPCport), opts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/rove/main.go
+++ b/cmd/rove/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -16,6 +17,7 @@ import (
 	"github.com/mdiluz/rove/proto/roveapi"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 var home = os.Getenv("HOME")
@@ -185,8 +187,12 @@ func InnerMain(command string, args ...string) error {
 		return fmt.Errorf("no host set in %s, set one with '%s config {HOST}'", ConfigPath(), os.Args[0])
 	}
 
+	tls := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
 	// Set up the server
-	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", config.Host, gRPCport), grpc.WithInsecure())
+	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", config.Host, gRPCport), grpc.WithTransportCredentials(credentials.NewTLS(tls)))
 	if err != nil {
 		return err
 	}

--- a/cmd/rove/main.go
+++ b/cmd/rove/main.go
@@ -187,7 +187,9 @@ func InnerMain(command string, args ...string) error {
 		return fmt.Errorf("no host set in %s, set one with '%s config {HOST}'", ConfigPath(), os.Args[0])
 	}
 
-	tls := &tls.Config{}
+	tls := &tls.Config{
+		InsecureSkipVerify: true,
+	}
 
 	// Set up the server
 	clientConn, err := grpc.Dial(fmt.Sprintf("%s:%d", config.Host, gRPCport), grpc.WithTransportCredentials(credentials.NewTLS(tls)))

--- a/cmd/rove/main_test.go
+++ b/cmd/rove/main_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func Test_InnerMain(t *testing.T) {
+	os.Setenv("NO_TLS", "1")
 
 	// Use temporary local user data
 	tmp, err := ioutil.TempDir(os.TempDir(), "rove-")

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -13,6 +13,7 @@ services:
       - DATA_PATH=/tmp/
       - WORDS_FILE=data/words_alpha.txt
       - TICK_RATE=10
+      - NO_TLS=1
     command: [ "./rove-server"]
 
   rove-tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - TICK_RATE=3
     volumes:
       - persistent-data:/mnt/rove-server:rw
+      - /etc/letsencrypt/:/etc/letsencrypt/
     command: [ "./rove-server"]
 
   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - DATA_PATH=/mnt/rove-server
       - WORDS_FILE=data/words_alpha.txt
       - TICK_RATE=3
+      - CERT_NAME=${CERT_NAME}
     volumes:
       - persistent-data:/mnt/rove-server:rw
       - /etc/letsencrypt/:/etc/letsencrypt/


### PR DESCRIPTION
This was missing before and makes sure we're a little more web-friendly and correct.

Cert files are assumed to come from letsencrypt.